### PR TITLE
Add Zod validation to /api/analyse endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "recharts": "^3.1.0",
-        "sentiment": "^5.0.2"
+        "sentiment": "^5.0.2",
+        "zod": "^4.0.14"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -23,6 +24,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/sentiment": "^5.0.4",
         "eslint": "^9",
         "eslint-config-next": "15.4.5",
         "jsdom": "^26.1.0",
@@ -2456,6 +2458,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/sentiment": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sentiment/-/sentiment-5.0.4.tgz",
+      "integrity": "sha512-6FL0CYijhnrR3gHbu7boAJn8zRCekJXBPfIHLkIgWbkY+hz5Dwfsq79FM7l/tLZKuEgQWktnzf6JqV2UCWKrbg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -8705,6 +8714,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.14.tgz",
+      "integrity": "sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "recharts": "^3.1.0",
-    "sentiment": "^5.0.2"
+    "sentiment": "^5.0.2",
+    "zod": "^4.0.14"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -25,6 +26,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/sentiment": "^5.0.4",
     "eslint": "^9",
     "eslint-config-next": "15.4.5",
     "jsdom": "^26.1.0",

--- a/src/app/api/analyse/route.ts
+++ b/src/app/api/analyse/route.ts
@@ -1,10 +1,22 @@
+import { AnalyseRequestSchema } from '@/lib/validation';
 import { NextResponse } from 'next/server';
 import Sentiment from 'sentiment';
 
 const sentiment = new Sentiment();
 
 export async function POST(req: Request) {
-  const { messages } = await req.json() as { user: string; text: string }[];
+ const json = await req.json();
+
+  // Validate request body with Zod
+  const result = AnalyseRequestSchema.safeParse(json);
+  if (!result.success) {
+    return NextResponse.json(
+      { error: result.error.message },
+      { status: 400 }
+    );
+  }
+
+  const { messages } = result.data;
 
   const counts: Record<string, number> = {};
   let totalSentiment = 0;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const MessageSchema = z.object({
+  user: z.string(),
+  text: z.string(),
+});
+
+export const AnalyseRequestSchema = z.object({
+  messages: z.array(MessageSchema),
+});
+
+export type AnalyseRequest = z.infer<typeof AnalyseRequestSchema>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom"
-  }
+  },
+   resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
 });


### PR DESCRIPTION
- Added Zod schemas to validate /api/analyse POST requests
- Returns 400 on invalid input with detailed error info
- Sets foundation for scalable, type-safe API
